### PR TITLE
feat:  getEmailClients方法返回值中添加harmonyOSBundleName属性

### DIFF
--- a/harmony/email_link/src/main/ets/RNEmailLinkTurboModule.ts
+++ b/harmony/email_link/src/main/ets/RNEmailLinkTurboModule.ts
@@ -23,7 +23,7 @@ import { Constants, prefixes, titles } from '../utils/Constants';
 export class RNEmailLinkTurboModule extends TurboModule implements TM.EmailLinkNativeModule.Spec {
   private context = getContext(this) as common.UIAbilityContext;
 
-  getEmailClients(): Promise<{ androidPackageName: string; title: string; prefix: string; iOSAppName: string; id: string; }[]> {
+  getEmailClients(): Promise<{ androidPackageName: string; title: string; prefix: string; iOSAppName: string; id: string; harmonyOSBundleName: string }[]> {
     return new Promise((resolve, reject) => {
       let availableApps = [];
       for (let app in prefixes) {
@@ -44,6 +44,7 @@ export class RNEmailLinkTurboModule extends TurboModule implements TM.EmailLinkN
             prefix: Constants.EMPTY,
             iOSAppName: Constants.EMPTY,
             id: title,
+            harmonyOSBundleName: title
           });
           result = acc;
         }


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- getEmailClients方法返回值中添加harmonyOSBundleName属性。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
